### PR TITLE
Disable UB sanitizer for a particular function

### DIFF
--- a/src/object_type_info.cpp
+++ b/src/object_type_info.cpp
@@ -84,6 +84,7 @@ object_type_info::call_table_message object_type_info::make_call_table_message(m
     return ret;
 }
 
+__attribute__((no_sanitize("undefined")))
 void object_type_info::fill_call_table()
 {
     // first pass


### PR DESCRIPTION
It produces "runtime error: applying non-zero offset 24 to null pointer" on line 161 when building on M1